### PR TITLE
My previous refactor broke dm-constraints (despite tests passing). This fixes it again.

### DIFF
--- a/lib/data_mapper/constraints/migrations/model.rb
+++ b/lib/data_mapper/constraints/migrations/model.rb
@@ -7,13 +7,6 @@ module DataMapper
     module Migrations
       module Model
 
-        # @api public
-        def auto_migrate!(repository_name = self.repository_name)
-          auto_migrate_constraints_down(repository_name)
-          super
-          auto_migrate_constraints_up(repository_name)
-        end
-
         # @api private
         def auto_migrate_constraints_up(repository_name = self.repository_name)
           # TODO: this check should not be here


### PR DESCRIPTION
I had misread the previous implementation, and it seemed sensible to tie constraint creation to model migration. 

But no, there's a reason that constraints are all removed before migrating down, and all added after migrating up.
