### PR TITLE
Allow the foreign keys generated for relationships to be DEFERRABLE.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -19,7 +19,6 @@ pure ruby.
 
 By default a relationship will PROTECT its children.
 
-
 === Cardinality Notes
  * 1:1
   * Applicable constraints: [:set_nil, :skip, :protect, :destroy]
@@ -31,13 +30,24 @@ By default a relationship will PROTECT its children.
   * Applicable constraints: [:skip, :protect, :destroy, :destroy!]
 
 
+=== Deferrability
+
+Optionally, a constraint may be made deferrable. This only affects the generated
+DDL, not any behavior in ruby. Set deferrability by adding the option
++:constraint_deferrable+ to the relationship with one of these values:
+
+  - false                         constraint is always evaluated immediately; it may not be deferred
+                                  (default)
+  - true or :initially_deferred   constraint may be deferred and is deferred by default
+  - :initially_immediate          constraint may be deferred but is immediate by default
+
 === Examples
 
   # 1:M Example
   class Post
     has n, :comments
     # equivalent to:
-    # has n, :comments, :constraint => :protect
+    # has n, :comments, :constraint => :protect, :constraint_deferrable => false
   end
 
   # M:M Example

--- a/lib/data_mapper/constraints/adapters/oracle_adapter.rb
+++ b/lib/data_mapper/constraints/adapters/oracle_adapter.rb
@@ -28,15 +28,13 @@ module DataMapper
         # @see DataMapper::Constraints::Adapters::DataObjectsAdapter#create_constraints_statement
         #
         # @api private
-        #
-        # TODO: is it desirable to always set `INITIALLY DEFERRED DEFERRABLE`?
-        def create_constraints_statement(storage_name, constraint_name, constraint_type, foreign_keys, reference_storage_name, reference_keys)
+        def create_constraints_statement(storage_name, constraint_name, constraint_type, deferrable, foreign_keys, reference_storage_name, reference_keys)
           DataMapper::Ext::String.compress_lines(<<-SQL)
             ALTER TABLE #{quote_name(storage_name)}
             ADD CONSTRAINT #{quote_name(constraint_name)}
             FOREIGN KEY (#{foreign_keys.join(', ')})
             REFERENCES #{quote_name(reference_storage_name)} (#{reference_keys.join(', ')})
-            INITIALLY DEFERRED DEFERRABLE
+            #{deferrable}
           SQL
         end
 

--- a/lib/data_mapper/constraints/relationship/one_to_many.rb
+++ b/lib/data_mapper/constraints/relationship/one_to_many.rb
@@ -4,6 +4,7 @@ module DataMapper
       module OneToMany
 
         attr_reader :constraint
+        attr_reader :constraint_deferrable
 
         # @api private
         def enforce_destroy_constraint(resource)
@@ -28,7 +29,7 @@ module DataMapper
       private
 
         ##
-        # Adds the delete constraint options to a relationship
+        # Adds the delete & defer constraint options to a relationship
         #
         # @param params [*ARGS] Arguments passed to Relationship#initialize
         #
@@ -43,6 +44,7 @@ module DataMapper
 
         def set_constraint
           @constraint = @options.fetch(:constraint, :protect) || :skip
+          @constraint_deferrable = @options.fetch(:constraint_deferrable, false)
         end
 
         # Checks that the constraint type is appropriate to the relationship
@@ -68,6 +70,11 @@ module DataMapper
 
           unless VALID_CONSTRAINT_VALUES.include?(@constraint)
             raise ArgumentError, ":constraint option must be one of #{VALID_CONSTRAINT_VALUES.to_a.join(', ')}"
+          end
+
+          return unless @constraint_validation
+          unless VALID_DEFERABLE_VALUES.include?(@constraint_validation)
+            raise ArgumentError, ":constraint_validation option must be one of #{VALID_DEFERABLE_VALUES.to_a.collect(&:inspect).join(', ')}"
           end
         end
 

--- a/lib/dm-constraints.rb
+++ b/lib/dm-constraints.rb
@@ -15,5 +15,6 @@ require 'data_mapper/constraints/adapters/abstract_adapter'
 module DataMapper
   module Constraints
     VALID_CONSTRAINT_VALUES = [ :protect, :destroy, :destroy!, :set_nil, :skip ].to_set.freeze
+    VALID_DEFERABLE_VALUES = [ false, true, :initially_deferred, :initially_immediate ].to_set.freeze
   end
 end

--- a/spec/integration/constraints_spec.rb
+++ b/spec/integration/constraints_spec.rb
@@ -625,6 +625,120 @@ describe 'DataMapper::Constraints', "(with #{DataMapper::Spec.adapter_name})" do
           end.should raise_error(ArgumentError)
         end
       end
+
+      # TODO: it's mostly the test itself which only works on
+      # PostgreSQL and MySQL (and any other database which has FKs and
+      # information_schema). The feature itself will work on any
+      # database that supports [NOT ]DEFERRABLE and INITIALLY
+      # [DEFERRED|IMMEDIATE], including, e.g., Oracle.
+      supported_by :postgres, :mysql do
+        describe 'with :constraint_deferrable =>' do
+          def deferrability_metadata(relationship)
+            adapter = DataMapper.repository(:default).adapter
+            constraint_name = # use private method from this lib for robustness
+              adapter.send(:constraint_name, relationship.child_model.storage_name, relationship.name)
+            adapter.select(
+              "SELECT is_deferrable, initially_deferred FROM information_schema.table_constraints WHERE constraint_name=?",
+              constraint_name).first
+          end
+
+          shared_examples_for 'not deferred' do
+            it 'is not deferrable' do
+              deferrability_metadata(Comment.relationships[:article]).is_deferrable.should == 'NO'
+            end
+
+            it 'is initially immediate' do
+              deferrability_metadata(Comment.relationships[:article]).initially_deferred.should == 'NO'
+            end
+          end
+
+          shared_examples_for 'all deferred' do
+            it 'is deferrable' do
+              deferrability_metadata(Comment.relationships[:article]).is_deferrable.should == 'YES'
+            end
+
+            it 'is initially deferred' do
+              deferrability_metadata(Comment.relationships[:article]).initially_deferred.should == 'YES'
+            end
+          end
+
+          describe 'not set' do
+            before :all do
+              class ::Article
+                has n, :comments
+              end
+
+              class ::Comment
+                belongs_to :article
+              end
+            end
+
+            it_should_behave_like 'not deferred'
+          end
+
+          describe 'false' do
+            before :all do
+              class ::Article
+                has n, :comments, :constraint_deferrable => false
+              end
+
+              class ::Comment
+                belongs_to :article
+              end
+            end
+
+            it_should_behave_like 'not deferred'
+          end
+
+          describe 'true' do
+            before :all do
+              class ::Article
+                has n, :comments, :constraint_deferrable => true
+              end
+
+              class ::Comment
+                belongs_to :article
+              end
+            end
+
+            it_should_behave_like 'all deferred'
+          end
+
+          describe ':initially_deferred' do
+            before :all do
+              class ::Article
+                has n, :comments, :constraint_deferrable => :initially_deferred
+              end
+
+              class ::Comment
+                belongs_to :article
+              end
+            end
+
+            it_should_behave_like 'all deferred'
+          end
+
+          describe ':initially_immediate' do
+            before :all do
+              class ::Article
+                has n, :comments, :constraint_deferrable => :initially_immediate
+              end
+
+              class ::Comment
+                belongs_to :article
+              end
+            end
+
+            it 'is deferrable' do
+              deferrability_metadata(Comment.relationships[:article]).is_deferrable.should == 'YES'
+            end
+
+            it 'is initially immediate' do
+              deferrability_metadata(Comment.relationships[:article]).initially_deferred.should == 'NO'
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/integration/constraints_spec.rb
+++ b/spec/integration/constraints_spec.rb
@@ -626,12 +626,12 @@ describe 'DataMapper::Constraints', "(with #{DataMapper::Spec.adapter_name})" do
         end
       end
 
-      # TODO: it's mostly the test itself which only works on
-      # PostgreSQL and MySQL (and any other database which has FKs and
-      # information_schema). The feature itself will work on any
-      # database that supports [NOT ]DEFERRABLE and INITIALLY
-      # [DEFERRED|IMMEDIATE], including, e.g., Oracle.
-      supported_by :postgres, :mysql do
+      # TODO: it's mostly the test itself which is only known to work
+      # on PostgreSQL. The feature itself will work on any database
+      # that supports [NOT ]DEFERRABLE and INITIALLY
+      # [DEFERRED|IMMEDIATE], including, e.g., Oracle, but excluding,
+      # e.g., MySQL.
+      supported_by :postgres do
         describe 'with :constraint_deferrable =>' do
           def deferrability_metadata(relationship)
             adapter = DataMapper.repository(:default).adapter


### PR DESCRIPTION
This commit adds a new option for relationships — `:constraint_deferrable`. It can be set to one of these values:
- `false` — constraint is always evaluated immediately; it may not be deferred (default)
- `true` or `:initially_deferred` — constraint may be deferred and is deferred by default
- `:initially_immediate` — constraint may be deferred but is immediate by default

If set, it will cause the migrations that generate the relationship's constraint to include DEFERRABLE and INITIALLY DEFERRED or INITIALLY IMMEDIATE.

Caveat: I've only tested this on PostgreSQL. From reading documentation, I believe it will work on Oracle as well. It will not work [on MySQL](http://dev.mysql.com/doc/refman/5.6/en/innodb-foreign-key-constraints.html) (scroll all the way to the end), but I have implemented it such that if the option isn't provided, the generated DDL is as it was without this patch.
